### PR TITLE
fix: move registry bucket to correct key in values file

### DIFF
--- a/gitlab-flux-values.yaml
+++ b/gitlab-flux-values.yaml
@@ -48,14 +48,13 @@ application:
         pages:
           name: pages.###ZARF_VAR_DOMAIN###
       registry:
+        bucket: uds-gitlab-registry###ZARF_VAR_BUCKET_SUFFIX###
         relativeurls: true
       pages:
         enabled: ###ZARF_VAR_GITLAB_PAGES_ENABLED###
         objectStore:
           bucket: uds-gitlab-pages###ZARF_VAR_BUCKET_SUFFIX###
       appConfig:
-        registry:
-          bucket: uds-gitlab-registry###ZARF_VAR_BUCKET_SUFFIX###
         lfs:
           bucket: uds-gitlab-lfs###ZARF_VAR_BUCKET_SUFFIX###
         artifacts:

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -3,7 +3,7 @@ kind: ZarfPackageConfig
 metadata:
   name: gitlab
   description: "UDS GitLab capability deployed via flux"
-  version: "0.1.5"
+  version: "0.1.6"
   architecture: amd64
 
 variables:


### PR DESCRIPTION
Move the `registry.bucket`key from `global.appConfig` to `global` to match upstream Big-Bang (https://docs.gitlab.com/charts/charts/globals#configure-appconfig-settings)

Background: `gitlab-flux-values.yaml:application.basevalues.global.appConfig` currently includes the key `registry.bucket` [here](https://github.com/defenseunicorns/uds-capability-gitlab/blob/main/gitlab-flux-values.yaml#L57) but upstream Big-Bang chart's `values.yaml:global.appConfig` does not have a `registry` [key](https://repo1.dso.mil/big-bang/product/packages/gitlab/-/blob/7.5.0-bb.0/chart/values.yaml?ref_type=tags#L237) and up-upstream Gitlab chart [documentation](https://docs.gitlab.com/charts/charts/globals#configure-appconfig-settings) doesn't identify a `registry` key in the `global.appConfig` key space